### PR TITLE
fix: update babel.js to disable simplify

### DIFF
--- a/lib/core/src/server/common/babel.js
+++ b/lib/core/src/server/common/babel.js
@@ -5,6 +5,7 @@ function createProdPresets() {
       {
         builtIns: false,
         mangle: false,
+        simplify: false
       },
     ],
   ];


### PR DESCRIPTION
A small fix to disable the simplify-feature of the babel's minify plugin as it stops the compilation of the storybook static build.